### PR TITLE
Fix torchvision version check

### DIFF
--- a/src/trackformer/util/misc.py
+++ b/src/trackformer/util/misc.py
@@ -21,7 +21,7 @@ import torchvision
 from torch import Tensor
 from visdom import Visdom
 
-if float(torchvision.__version__[:3]) < 0.7:
+if int(torchvision.__version__.split('.')[0]) <= 0 and int(torchvision.__version__.split('.')[1]) < 7:
     from torchvision.ops import _new_empty_tensor
     from torchvision.ops.misc import _output_size
 
@@ -452,7 +452,7 @@ def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corne
     This will eventually be supported natively by PyTorch, and this
     class can go away.
     """
-    if float(torchvision.__version__[:3]) < 0.7:
+    if int(torchvision.__version__.split('.')[0]) <= 0 and int(torchvision.__version__.split('.')[1]) < 7:
         if input.numel() > 0:
             return torch.nn.functional.interpolate(
                 input, size, scale_factor, mode, align_corners


### PR DESCRIPTION
Previously the code takes the first 3 chars from `torchvision.__version__` and converts it into a float number to check if the version is earlier than 0.7.
This logic works for version <= 0.9 but the latest version is 0.10 so it cannot pass the version check (the extracted float number would be 0.1 < 0.7).
I fixed this part by comparing the major version number and the minor version number separately.
```
if int(torchvision.__version__.split('.')[0]) <= 0 and int(torchvision.__version__.split('.')[1]) < 7:
    from torchvision.ops import _new_empty_tensor
    from torchvision.ops.misc import _output_size
```

This logic would make sure the future versions pass the version check.